### PR TITLE
doc: fix minor grammar mistake

### DIFF
--- a/examples/thor.rs
+++ b/examples/thor.rs
@@ -6,7 +6,7 @@ use thunder::thunderclap;
 
 struct Thor;
 
-/// An application that shoots lightning out of it's hands
+/// An application that shoots lightning out of its hands
 #[thunderclap]
 impl Thor {
     /// Say hello to someone at home


### PR DESCRIPTION
it's -> its for possessive use.