### PR TITLE
Add repository field to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Katharina Fey <kookie@spacekookie.de>"]
 license = "MIT/X11 OR Apache-2.0"
 readme = "README.md"
 documentation = "https://docs.rs/thunder"
+repository = "https://github.com/spacekookie/thunder"
 keywords = ["argument", "cli", "arg", "parser", "parse"]
 categories = ["command-line-interface"]
 


### PR DESCRIPTION
Just a minor [C-METADATA](https://rust-lang-nursery.github.io/api-guidelines/documentation.html#cargotoml-includes-all-common-metadata-c-metadata) patch, but will hopefully make your crate a little more friendly to other development tools.